### PR TITLE
Update test_add_link_before

### DIFF
--- a/linked_list_unit_test.py
+++ b/linked_list_unit_test.py
@@ -18,12 +18,14 @@ class LinkedListTest(unittest.TestCase):
         self.assertEqual(self.ll.get_front(), "A")
 
     # Inserts A at index 0, B at index 1 and C at index 2. Asserts A is at the front and C is at the back.
+    # test_add_link_before: Changed indexes to match assignment 3 guidelines example, does not allow for creating a
+    # new node past the list's length
     def test_add_link_before(self):
         self.ll.add_link_before("A", 0)
-        self.ll.add_link_before("B", 1)
-        self.ll.add_link_before("C", 2)
-        self.assertEqual(self.ll.get_front(), "A")
-        self.assertEqual(self.ll.get_back(), "C")
+        self.ll.add_link_before("B", 0)
+        self.ll.add_link_before("C", 1)
+        self.assertEqual(self.ll.get_front(), "B")
+        self.assertEqual(self.ll.get_back(), "A")
 
     # Tries to insert Z at index 26 in an empty list, verifies an IndexError is raised.
     def test_add_link_before_out_of_bounds(self):


### PR DESCRIPTION
Changed indexes to match assignment 3 guidelines example*. From my understanding, it should not allow for creating a new node past the list's length.  That is, a list of one item with index 0, shouldn't allow add_link("B", 1) because the index 1 you point to doesn't exist. *(see Programming_Assignment3_Guidelines - Updated.pdf for example)
I think I'm right on the above, but I'm not sure I'm doing any of the GitHub side of this correct.  I'm mostly doing this to practice GitHub as you suggested. Thanks for putting this test together and your patience!
